### PR TITLE
Set css display to "" on notification close

### DIFF
--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -54,7 +54,7 @@
 
   onClose = function() {
     this.options.onClose();
-    $(this.$note).remove();
+    $(this.$note).remove().css("display", "");
     this.options.onClosed();
   };
 


### PR DESCRIPTION
When the notification is hidden (via boostrap-alert), a style of display:none is added. By removing this styling, the same notification object can be re-used.

ie. you can do:

```
var _notif = $('.elem').notify();
_notif.show();
// wait some time for it to fade out, then...
_notif.show() // this will display again; previously nothing would be visible due to the display:none
```
