### PR TITLE
Add support for bootstrap icons and fix overlapping of elements

### DIFF
--- a/css/bootstrap-notify.css
+++ b/css/bootstrap-notify.css
@@ -1,4 +1,4 @@
-.notifications{position:fixed;}.notifications.top-right{right:10px;top:25px;}
+.notifications{position:fixed;z-index:9999;}.notifications.top-right{right:10px;top:25px;}
 .notifications.top-left{left:10px;top:25px;}
 .notifications.bottom-left{left:10px;bottom:25px;}
 .notifications.bottom-right{right:10px;bottom:25px;}

--- a/css/bootstrap-notify.less
+++ b/css/bootstrap-notify.less
@@ -14,6 +14,7 @@
 
 .notifications {
   position: fixed;
+  z-index:9999;
 
   &.top-right {
     right: @right;

--- a/examples/index.html
+++ b/examples/index.html
@@ -181,6 +181,12 @@
                 <td>...</td>
                 <td>Called after alert closes.</td>
               </tr>
+              <tr>
+                <td>icon</td>
+                <td>string</td>
+                <td>...</td>
+                <td>Bootstrap icon to display in the notification, omit <code>icon-</code> from icon name.</td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -50,6 +50,9 @@
       $(this._link).on('click', $.proxy(Notification.onClose, this)),
       this.$note.prepend(this._link);
 
+    if (this.options.icon)
+	  this.$note.prepend('<i class="icon-' + this.options.icon + '"></i> ');
+	  
     return this;
   };
 
@@ -81,6 +84,7 @@
     type: 'success',
     closable: true,
     transition: 'fade',
+	icon: false,
     fadeOut: {
       enabled: true,
       delay: 3000

--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -84,7 +84,7 @@
     type: 'success',
     closable: true,
     transition: 'fade',
-	icon: false,
+    icon: false,
     fadeOut: {
       enabled: true,
       delay: 3000

--- a/js/bootstrap-notify.js
+++ b/js/bootstrap-notify.js
@@ -51,7 +51,7 @@
       this.$note.prepend(this._link);
 
     if (this.options.icon)
-	  this.$note.prepend('<i class="icon-' + this.options.icon + '"></i> ');
+      this.$note.prepend('<i class="icon-' + this.options.icon + '"></i> ');
 	  
     return this;
   };


### PR DESCRIPTION
Add support for bootstrap icons, code originally from @stalinb87. But his pull request was all over the place. He was also missing the icon- bit in the class. Also fixes #6 overlapping with other elements
